### PR TITLE
Handle failure of requirement generation when `pip` is not installed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle failure of requirement generation when `pip` is not installed.
+
 ## [2.1.1] - 2025-11-03
 
 ### Fixed

--- a/src/ewoks/_requirements/pip/extract.py
+++ b/src/ewoks/_requirements/pip/extract.py
@@ -44,11 +44,14 @@ def extract_pip_requirements(graph: TaskGraph) -> List[str]:
 
 
 def add_current_env_pip_requirements(graph: TaskGraph) -> TaskGraph:
-    freeze_output = subprocess.check_output(
-        [sys.executable, "-m", "pip", "freeze"], text=True
-    )
+    try:
+        freeze_output = subprocess.check_output(
+            [sys.executable, "-m", "pip", "freeze"], text=True
+        )
+    except subprocess.CalledProcessError as ex:
+        logger.warning("Cannot generate list of requirements with 'pip' (%s).", ex)
+        return graph
+
     requirements = freeze_output.strip().split("\n")
-
     graph.graph.graph["requirements"] = requirements
-
     return graph


### PR DESCRIPTION
***In GitLab by @woutdenolf on Nov 6, 2025, 10:20 GMT+1:***



**Assignees:** @woutdenolf

**Reviewers:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/232*