### PR TITLE
missing image doc stage

### DIFF
--- a/.gitlab-ci-template.yml
+++ b/.gitlab-ci-template.yml
@@ -13,6 +13,10 @@ stages:
   extends: ".base"
   image: "python:3.6"
 
+.doc:
+  extends: ".base"
+  image: "python:3.6"
+
 flake8:
   stage: style
   extends: ".style"
@@ -31,7 +35,7 @@ black:
 
 .sphinx:
   stage: doc
-  extends: ".base"
+  extends: ".doc"
   before_script:
     - pip install .[doc]
   script:


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jul 9, 2021, 22:36 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/7*