### PR TITLE
Update .gitlab-ci-template.yml fix typo

### DIFF
--- a/.gitlab-ci-template.yml
+++ b/.gitlab-ci-template.yml
@@ -53,7 +53,7 @@ black:
 .sphinx_and_artifacts:
   stage: doc
   extends: ".sphinx"
-  before_Script:
+  before_script:
     - rm -rf artifacts
     - mkdir artifacts
   after_script:


### PR DESCRIPTION
***In GitLab by @payno on Jul 26, 2021, 10:29 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/13*