### PR TITLE
use the default testpypi name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,6 @@ pytest --pyargs <project_name>
 4. Deploy on [pypitest](https://test.pypi.org) and [pypi](https://pypi.org)
    ```bash
    python setup.py sdist
-   twine upload -r pypitest --sign dist/*
+   twine upload -r testpypi --sign dist/*
    twine upload -r pypi --sign dist/*
    ```


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jul 29, 2021, 10:50 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/14*