### PR TITLE
use the release version of ewokscore

### DIFF
--- a/.gitlab-ci-template.yml
+++ b/.gitlab-ci-template.yml
@@ -73,7 +73,7 @@ black:
     # keep for the extensions
   script:
     - pip install pytest-cov
-    - pip install .[test]
+    - pip install --pre .[test]
     - pytest --cov=./ .
 
 .test-3.6:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires = 
-    ewokscore @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewokscore.git@main
+    ewokscore
 
 [options.extras_require]
 dask = 
@@ -32,7 +32,7 @@ test =
     pytest
     testbook
     ipykernel
-    ewokscore[test] @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewokscore.git@main
+    ewokscore[test]
     ewoksdask[test] @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewoksdask.git@main
     ewoksppf[test] @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewoksppf.git@main
     ewoksorange[test] @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewoksorange.git@main
@@ -41,7 +41,7 @@ dev =
     black
     flake8
     flake8_nb
-    ewokscore[dev] @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewokscore.git@main
+    ewokscore[dev]
     ewoksdask[dev] @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewoksdask.git@main
     ewoksppf[dev] @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewoksppf.git@main
     ewoksorange[dev] @ git+https://git@gitlab.esrf.fr/workflow/ewoks/ewoksorange.git@main


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jul 30, 2021, 16:31 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/16*