### PR TITLE
fix typo in .gitlab-ci-template.yml

### DIFF
--- a/.gitlab-ci-template.yml
+++ b/.gitlab-ci-template.yml
@@ -98,7 +98,7 @@ black:
 
 .deploy:
   stage: deploy
-  extend: ".base"
+  extends: ".base"
   image: "docker-registry.esrf.fr/dau/ewoks:python_3.6"
   script:
     - rm -rf public


### PR DESCRIPTION
***In GitLab by @payno on Aug 4, 2021, 08:51 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/19*