### PR TITLE
bug in graph conversion

### DIFF
--- a/ewoks/bindings.py
+++ b/ewoks/bindings.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Optional, List
+from typing import Any, Optional, List, Tuple
 
 
 def import_binding(binding: Optional[str]):
@@ -10,7 +10,13 @@ def import_binding(binding: Optional[str]):
     return importlib.import_module(binding)
 
 
-def as_ewoks_graph(graph, binding: Optional[str], **load_graph_options):
+def as_ewoks_graph(
+    graph: Any, binding: Optional[str], **load_graph_options
+) -> Tuple[Any, bool]:
+    """Returns a 2-tuple where the first element is a graph and the second a boolean that
+    indicates whether the graph has been loaded (i.e. using the `load_graph_options`)
+    or not (i.e. simply return the `graph` argument).
+    """
     if isinstance(graph, str) and graph.endswith(".ows") and binding != "orange":
         mod = importlib.import_module("ewoksorange.bindings")
         return mod.ows_to_ewoks(graph, **load_graph_options), True


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 25, 2022, 11:21 GMT+1:***

`load_options` could be `None` in which case `**load_options` will not work.

In addition it is not necessary to save the ewoks graph in a temporary file after conversion from .ows

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/64*