### PR TITLE
setuptools should not import when installing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=46.4<63",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 3, 2022, 21:26 GMT+2:***

Reported by @julia.garriga

![image](https://gitlab.esrf.fr/workflow/ewoks/ewoks/uploads/606160beffb4df6385ec85ab87055dd0/image.png)

Older versions of setuptools import when installing

https://redirect.github.com/pypa/setuptools/blob/main/CHANGES.rst#v4640

Then it seems it wants to build wheels

![image](https://gitlab.esrf.fr/workflow/ewoks/ewoks/uploads/1cab0b61dfa9ad1de8df1e6740c9ea7e/image.png)

**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/73*