### PR TITLE
gitlab CI: env variables can no longer be used in artifact paths

### DIFF
--- a/.gitlab-ci-template.yml
+++ b/.gitlab-ci-template.yml
@@ -87,6 +87,11 @@ stages:
   variables:
     ARTIFACTS_SOURCE: dist
     ARTIFACTS_DEST: sdist
+  artifacts:
+    paths:
+      - sdist/
+    when: on_success
+    expire_in: 2h
 
 .test_build:
   stage: test_build
@@ -167,6 +172,11 @@ black:
   variables:
     ARTIFACTS_SOURCE: build/sphinx/html
     ARTIFACTS_DEST: html
+  artifacts:
+    paths:
+      - html/
+    when: on_success
+    expire_in: 2h
 
 .pages:
   stage: deploy


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 30, 2022, 10:55 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/81*