### PR TITLE
include class members without docstring

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -4,6 +4,7 @@
 
 .. autoclass:: {{ objname }}
    :members:
+   :undoc-members:
    :show-inheritance:
    :inherited-members:
 


### PR DESCRIPTION
***In GitLab by @woutdenolf on Oct 19, 2022, 23:03 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/110*