### PR TITLE
ewokscore does not support the CLI binding argument anymore

### DIFF
--- a/src/ewoks/cliutils.py
+++ b/src/ewoks/cliutils.py
@@ -1,4 +1,3 @@
-from warnings import warn
 from ewokscore.cliutils import add_execute_parameters as _add_execute_parameters
 from ewokscore.cliutils import apply_execute_parameters
 from ewokscore.cliutils import add_convert_parameters  # noqa F401
@@ -28,8 +27,3 @@ def add_submit_parameters(parser, shell=False):
 
 def apply_submit_parameters(args, shell=False):
     apply_execute_parameters(args, shell=shell)
-    if args.binding:
-        if args.engine:
-            raise ValueError("--binding and --engine cannot be used together")
-        args.engine = args.binding
-        warn("--binding is deprecated in favor of --engine", FutureWarning)


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 20, 2023, 13:43 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/128*