### PR TITLE
when no outputs are requested stay silent

### DIFF
--- a/src/ewoks/__main__.py
+++ b/src/ewoks/__main__.py
@@ -26,7 +26,8 @@ def create_argument_parser(shell=False):
 def command_execute(args, shell=False):
     cliutils.apply_execute_parameters(args, shell=shell)
     results = execute_graph(args.graph, engine=args.engine, **args.execute_options)
-    print("Result of workflow '%s':\n%s" % (args.workflow, pformat(results)))
+    if args.outputs != "none":
+        print("Result of workflow '%s':\n%s" % (args.workflow, pformat(results)))
 
     if shell:
         if results is None:


### PR DESCRIPTION
***In GitLab by @woutdenolf on Feb 2, 2024, 15:16 GMT+1:***

```
ewoks execute demo --test --outputs=end
Result of workflow 'demo':
{'task6': {'result': 18}}
```

But without outputs we print useless lines

```
ewoks execute demo --test
Result of workflow 'demo':
{}
```

It should just be no output

```
ewoks execute demo --test
```

**Assignees:** @woutdenolf

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/155*