### PR TITLE
python 3.9 importlib is broken

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ test_sdist-3.9_glx:
     - python -m pytest -v --pyargs ewoksorange.tests
   variables:
     JUPYTER_PLATFORM_DIRS: 1
-    PYTEST_WARNINGS: "-W error ${IGNORE_WARNINGS}"
+    PYTEST_WARNINGS: "-W error ${IGNORE_WARNINGS} -W ignore::RuntimeWarning:networkx.utils.backends" # networkx #7372
   timeout: 15m
 
 test_sdist-3.10_glx:


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 27, 2024, 20:06 GMT+1:***

See https://redirect.github.com/networkx/networkx/issues/7372

**Assignees:** @woutdenolf

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/161*