### PR TITLE
pyproject.toml: fix parsing error from pip 24.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=46.4<63",
+    "setuptools>=46.4,<63",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
***In GitLab by @payno on Jun 21, 2024, 09:24 GMT+2:***



**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/165*