### PR TITLE
Ewoks install can now install packages in a different env where it is run

### DIFF
--- a/src/ewoks/__main__.py
+++ b/src/ewoks/__main__.py
@@ -176,7 +176,7 @@ def command_install(args, shell=False):
     cliutils.apply_install_parameters(args, shell=shell)
     for workflow, graph in zip(args.workflows, args.graphs):
         try:
-            install_graph(graph, args.yes)
+            install_graph(graph, args.yes, args.python)
         except (CalledProcessError, ValueError) as e:
             print(f"Install failed for {workflow}: {e}")
         except AbortException:

--- a/src/ewoks/bindings.py
+++ b/src/ewoks/bindings.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import importlib
+import sys
 from warnings import warn
 from typing import Any, Optional, List, Union
 from ewokscore.graph import TaskGraph
@@ -159,6 +160,7 @@ def convert_graph(
 def install_graph(
     source,
     skip_prompt: bool = False,
+    python_path: Optional[str] = None,
     load_options: Optional[dict] = None,
 ):
     if load_options is None:
@@ -169,15 +171,18 @@ def install_graph(
     if requirements is None:
         raise ValueError("No requirements field")
 
+    if python_path is None:
+        python_path = sys.executable
+
     if skip_prompt:
-        pip_install(requirements)
+        pip_install(requirements, python_path)
         return
 
     answer = input(
-        f'This will run `pip install {" ".join(requirements)}` in the current env. Do you want to proceed (y/N)?'
+        f'This will run f`{python_path} -m pip install {" ".join(requirements)}`. Do you want to proceed (y/N)?'
     )
     if answer.lower() == "y" or answer.lower() == "yes":
-        pip_install(requirements)
+        pip_install(requirements, python_path)
     else:
         raise AbortException()
 

--- a/src/ewoks/cliutils/cli_install_utils.py
+++ b/src/ewoks/cliutils/cli_install_utils.py
@@ -24,6 +24,12 @@ def add_install_parameters(parser: ArgumentParser):
         action="store_true",
         help="Accept automatically install prompts",
     )
+    parser.add_argument(
+        "-p",
+        "--python",
+        type=str,
+        help="Python of the env where the packages should be installed. Default: current env Python.",
+    )
 
 
 def apply_install_parameters(args):

--- a/src/ewoks/cliutils/utils.py
+++ b/src/ewoks/cliutils/utils.py
@@ -1,7 +1,6 @@
 import os
 import json
 import subprocess
-import sys
 from glob import glob
 from fnmatch import fnmatch
 from typing import Sequence, Tuple, Any, List
@@ -119,8 +118,6 @@ def parse_destinations(args):
     return destinations
 
 
-def pip_install(requirements: Sequence[str]) -> int:
+def pip_install(requirements: Sequence[str], python_path: str) -> int:
     # https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program
-    return subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", *requirements]
-    )
+    return subprocess.check_call([python_path, "-m", "pip", "install", *requirements])

--- a/src/ewoks/tests/test_cli.py
+++ b/src/ewoks/tests/test_cli.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 import pytest
 
-import ewoks
 from ewoks.__main__ import main
 from ewokscore import load_graph
 from ewokscore.tests.examples.graphs import graph_names
@@ -65,20 +64,17 @@ def test_convert(graph_name, tmpdir):
 
 
 def test_install(venv):
-    ewoks_package_path = os.path.dirname(
-        os.path.dirname(os.path.dirname(ewoks.__file__))
-    )
-    venv.install(ewoks_package_path)
-
     with pytest.raises(Exception, match="package is not installed"):
         venv.get_version("ewoksdata")
 
     subprocess.check_call(
         [
-            os.path.join(venv.bin, "ewoks"),
+            "ewoks",
             "install",
             "--yes",
             '{"graph": {"id": "test_install", "requirements": ["ewoksdata"]}}',
+            "-p",
+            f"{venv.python}",
         ]
     )
 


### PR DESCRIPTION
***In GitLab by @loichuder on Oct 8, 2024, 13:27 GMT+2:***

Not only this makes `ewoks install` more flexible but it fixes #30 since it is no longer needed to run `ewoks install` from the env where the package will be installed.

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/174*