### PR TITLE
Save current env as requirements when running ewoks convert/execute with convert

### DIFF
--- a/src/ewoks/bindings.py
+++ b/src/ewoks/bindings.py
@@ -10,7 +10,7 @@ from ewokscore.events.contexts import job_context, RawExecInfoType
 
 from .cliutils.utils import AbortException
 from .cliutils.utils import pip_install
-from .utils import extract_requirements
+from .utils import extract_requirements, save_current_env_as_requirements
 from . import graph_cache
 
 try:
@@ -75,9 +75,7 @@ def execute_graph(
 
         # Save the graph (with inputs)
         if convert_destination is not None:
-            if save_options is None:
-                save_options = dict()
-            save_graph(graph, convert_destination, **save_options)
+            convert_graph(graph, convert_destination, save_options=save_options)
 
         # Execute the graph
         mod = import_binding(engine)
@@ -122,7 +120,10 @@ def submit_graph(
     if resolve_graph_remotely:
         options["load_options"] = load_options
     else:
-        graph = convert_graph(graph, None, load_options=load_options)
+        # Do not save requirements since the current env is the client
+        graph = convert_graph(
+            graph, None, load_options=load_options, save_requirements=False
+        )
     return submit(args=(graph,), kwargs=options, **_celery_options)
 
 
@@ -151,12 +152,15 @@ def convert_graph(
     inputs: Optional[List[dict]] = None,
     load_options: Optional[dict] = None,
     save_options: Optional[dict] = None,
+    save_requirements: bool = True,
 ) -> Union[str, dict]:
     if load_options is None:
         load_options = dict()
     if save_options is None:
         save_options = dict()
     graph = load_graph(source, inputs=inputs, **load_options)
+    if save_requirements:
+        graph = save_current_env_as_requirements(graph)
     return save_graph(graph, destination, **save_options)
 
 

--- a/src/ewoks/tests/test_cli.py
+++ b/src/ewoks/tests/test_cli.py
@@ -6,9 +6,20 @@ import pytest
 
 from ewoks.__main__ import main
 from ewokscore import load_graph
+from ewokscore.graph import TaskGraph
 from ewokscore.tests.examples.graphs import graph_names
 from ewokscore.tests.examples.graphs import get_graph
 from ewokscore.tests.utils.results import assert_execute_graph_default_result
+
+
+def _ewokscore_in_graph_requirements(graph: TaskGraph) -> bool:
+    ewokscore_in_req = False
+    for requirement in graph.graph.graph["requirements"]:
+        if "ewokscore" in requirement:
+            ewokscore_in_req = True
+            break
+
+    return ewokscore_in_req
 
 
 @pytest.mark.parametrize("graph_name", graph_names())
@@ -63,6 +74,10 @@ def test_convert(graph_name, tmpdir):
     main(argv=argv, shell=False)
     assert os.path.exists(destination)
 
+    graph = load_graph(destination)
+    assert graph.graph.graph["requirements"] is not None
+    assert _ewokscore_in_graph_requirements(graph)
+
 
 def test_install(venv):
     with pytest.raises(Exception, match="package is not installed"):
@@ -113,3 +128,31 @@ def test_install_with_extract(venv):
     )
 
     assert venv.get_version("ewoksdata") is not None
+
+
+def test_execute_with_convert_destination(tmpdir):
+    destination = str(tmpdir / "convert.json")
+    argv = [
+        sys.executable,
+        "execute",
+        "demo",
+        "--test",
+        "-p",
+        "task1:b=42",
+        "-o",
+        f"convert_destination={destination}",
+    ]
+
+    main(argv=argv, shell=False)
+    assert os.path.exists(destination)
+
+    graph = load_graph(destination)
+
+    task1_node = graph.graph.nodes["task1"]
+    assert task1_node["default_inputs"][-1] == {
+        "name": "b",
+        "value": 42,
+    }
+
+    assert graph.graph.graph["requirements"] is not None
+    assert _ewokscore_in_graph_requirements(graph)

--- a/src/ewoks/utils.py
+++ b/src/ewoks/utils.py
@@ -1,4 +1,6 @@
 import logging
+import subprocess
+import sys
 from typing import List
 from ewokscore.graph import TaskGraph
 
@@ -44,3 +46,15 @@ def extract_requirements(graph: TaskGraph) -> List[str]:
             )
 
     return list(imports)
+
+
+def save_current_env_as_requirements(graph: TaskGraph):
+
+    freeze_output = subprocess.check_output(
+        [sys.executable, "-m", "pip", "freeze"], text=True
+    )
+    requirements = freeze_output.strip().split("\n")
+
+    graph.graph.graph["requirements"] = requirements
+
+    return graph


### PR DESCRIPTION
***In GitLab by @loichuder on Oct 17, 2024, 10:09 GMT+2:***

For #26 

When running `ewoks convert`/`execute -o convert_destination=...`, `pip freeze` is run on the current env and the output is saved as the `requirements` field of the output graph.

Rereading your comment, you wanted to have `ewoks convert` save the requirements only if the field is empty ? Perhaps I should add an arg `force_req_save` to `ewoks convert` ? By default (not specified), it will save the requirements only if the field is empty. If specified, it overwrites the existing requirments ?

What do you think ?

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/177*