### PR TITLE
bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG.md
 
+## 1.2.0
+
+New features:
+
+- Ewoks CLI `show` command: print all workflow parameters that are not connected to outputs from other nodes.
+
 ## 1.1.0
+
+Changes:
 
 - Drop Python 3.6 and 3.7 and add support for Python 3.13
 
@@ -28,18 +36,18 @@ New features:
 
 Changes:
 
-- client-side graph resolution by default for submitting workflows
+- Client-side graph resolution by default for submitting workflows.
 
 Bug fixes:
 
-- the pyyaml 6.0.2rc1 package is broken
+- The pyyaml 6.0.2rc1 package is broken.
 
 ## 0.4.3
 
 Changes:
 
-- ewoks CLI workflow search: sort by creation date
-- ewoks CLI convert: support multiple workflow arguments
+- Ewoks CLI workflow search: sort by creation date.
+- Ewoks CLI `convert` command: support multiple workflow arguments.
 
 ## 0.4.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ewoks"
-version = "1.1.0"
+version = "1.2.0"
 authors = [{ name = "ESRF", email = "dau-pydev@esrf.fr" }]
 description = "Extensible Workflow System"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 12, 2025, 08:56 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/206*