### PR TITLE
Resolve "Docs: add “copy to clipboard” button to code blocks"

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,0 +1,7 @@
+button.copybtn {
+    opacity: 0.3;
+}
+
+button.copybtn:hover {
+    opacity: 1;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,12 +23,12 @@ extensions = [
     "sphinx_autodoc_typehints",
     "nbsphinx",
     "nbsphinx_link",
+    "sphinx_copybutton",
 ]
 templates_path = ["_templates"]
 exclude_patterns = ["build", "**.ipynb_checkpoints"]
 
 always_document_param_types = True
-
 
 autosummary_generate = True
 autodoc_default_flags = [
@@ -37,12 +37,15 @@ autodoc_default_flags = [
     "show-inheritance",
 ]
 
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "pydata_sphinx_theme"
-html_static_path = []
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 html_theme_options = {
     "icon_links": [
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ doc = [
     "nbsphinx_link",
     "pydata-sphinx-theme",
     "sphinx-argparse",
+    "sphinx-copybutton",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
***In GitLab by @woutdenolf on Aug 17, 2025, 12:28 GMT+2:***

Closes #46

![image](https://gitlab.esrf.fr/workflow/ewoks/ewoks/uploads/516b4c236d2fdc729c095fd4f568d316/image.png)

**Assignees:** @woutdenolf

**Reviewers:** andy.gotz

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/218*