### PR TITLE
Use ruff in CI to check Python and notebook files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,11 @@ jobs:
   # Run linter / checks
   checks:
     uses: ewoks-kit/.github/.github/workflows/python-check.yml@main
+    with:
+      enable-black: "false"
+      enable-flake8: "false"
+      enable-isort: "false"
+      enable-ruff: "true"
 
   # Build documentation
   docs:

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 !.gitignore
 !.github
 !.readthedocs.yaml
-!.flake8
-!.flake8_nb
 
 # Byte / compiled / optimized
 *.py[cod]
@@ -17,6 +15,7 @@ __pycache__/
 *.egg-info/
 .eggs/
 /doc/reference/_generated
+uv.lock
 
 # Dask
 dask-worker-space/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-<a href="https://github.com/ewoks-kit/.github/blob/main/shared/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a>
+<a href="https://github.com/ewoks-kit/.github/blob/main/shared/CONTRIBUTING_ruff.md" target="_blank">CONTRIBUTING.md</a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ewoks: Extensible Workflow System
 
 [![Pipeline](https://github.com/ewoks-kit/ewoks/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/ewoks-kit/ewoks/actions/workflows/test.yml)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License](https://img.shields.io/github/license/ewoks-kit/ewoks)](https://github.com/ewoks-kit/ewoks/blob/main/LICENSE.md)
 [![Coverage](https://codecov.io/gh/ewoks-kit/ewoks/branch/main/graph/badge.svg)](https://codecov.io/gh/ewoks-kit/ewoks)
 [![Docs](https://readthedocs.org/projects/ewoks/badge/?version=latest)](https://ewoks.readthedocs.io/en/latest/?badge=latest)

--- a/doc/howtoguides/ewoks_ppf.ipynb
+++ b/doc/howtoguides/ewoks_ppf.ipynb
@@ -52,8 +52,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ewokscore import Task\n",
     "import numpy\n",
+    "from ewokscore import Task\n",
     "\n",
     "\n",
     "class MatrixGeneration(\n",
@@ -191,9 +191,9 @@
    "source": [
     "import os\n",
     "\n",
-    "from ewoks import execute_graph\n",
-    "\n",
     "from ewoksutils.task_utils import task_inputs\n",
+    "\n",
+    "from ewoks import execute_graph\n",
     "\n",
     "inputs = [\n",
     "    *task_inputs(\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,7 @@ test = [
     "pyqt5",
     "pytest-venv",
 ]
-dev = [
-    "ewoks[test]",
-    "black[jupyter] >=25",
-    "flake8 >=4",
-    "flake8_nb >= 0.3.1",
-    "isort",
-]
+dev = ["ewoks[test]", "ruff"]
 doc = [
     "ewoks[test]",
     "sphinx >=4.5",
@@ -77,12 +71,19 @@ where = ["src"]
 [tool.coverage.run]
 omit = ['*/tests/*']
 
-[tool.isort]
-profile = "black"
-force_single_line = "True"
-
 [project.scripts]
 ewoks = "ewoks.__main__:main"
 
 [tool.setuptools.package-data]
-"ewoks.tests.notebooks"= ["*.ipynb"]
+"ewoks.tests.notebooks" = ["*.ipynb"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `S101` (assert used violations) in all test files
+"src/ewoks/tests/*.py" = ["S101"]
+
+[tool.ruff.lint.isort]
+force-single-line = true

--- a/src/ewoks/_engines.py
+++ b/src/ewoks/_engines.py
@@ -81,9 +81,10 @@ def get_serialization_engine(
     return get_execution_engine("core"), core_representation
 
 
-def _iter_engine_class_loaders_with_name() -> (
-    Generator[Tuple[str, Callable[[], None]], None, None]
-):
+_EngineClassLoaderGenerator = Generator[Tuple[str, Callable[[], None]], None, None]
+
+
+def _iter_engine_class_loaders_with_name() -> _EngineClassLoaderGenerator:
     try:
         eps = entry_points(group="ewoks.engines")
     except Exception:
@@ -94,9 +95,7 @@ def _iter_engine_class_loaders_with_name() -> (
         yield ep.name, ep.load
 
 
-def _iter_engine_class_loaders_with_representation() -> (
-    Generator[Tuple[str, Callable[[], None]], None, None]
-):
+def _iter_engine_class_loaders_with_representation() -> _EngineClassLoaderGenerator:
     try:
         eps = entry_points(group="ewoks.engines.serialization.representations")
     except Exception:

--- a/src/ewoks/tests/notebooks/benchmark.ipynb
+++ b/src/ewoks/tests/notebooks/benchmark.ipynb
@@ -18,10 +18,12 @@
    "outputs": [],
    "source": [
     "import time\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
+    "from ewokscore.tests.examples.tasks.addfunc import addfunc\n",
     "from ewoksutils.import_utils import qualname\n",
-    "from ewoks import execute_graph\n",
-    "from ewokscore.tests.examples.tasks.addfunc import addfunc"
+    "\n",
+    "from ewoks import execute_graph"
    ]
   },
   {

--- a/src/ewoks/tests/notebooks/running_workflows.ipynb
+++ b/src/ewoks/tests/notebooks/running_workflows.ipynb
@@ -20,10 +20,11 @@
     "import os\n",
     "import shutil\n",
     "\n",
-    "from ewoks import execute_graph\n",
-    "from ewokscore.variable import value_from_transfer\n",
+    "from ewokscore.tests.examples.graphs import get_graph\n",
     "from ewokscore.tests.utils.show import show_graph\n",
-    "from ewokscore.tests.examples.graphs import get_graph"
+    "from ewokscore.variable import value_from_transfer\n",
+    "\n",
+    "from ewoks import execute_graph"
    ]
   },
   {


### PR DESCRIPTION
To fix https://github.com/ewoks-kit/ewoks/pull/61#issuecomment-4010253909

I could not run `flake8_nb` locally so I thought we might as well move to `ruff`.

`ruff` is smarter than `flake8_nb` and only raises an error if the import is not at the top of the **cell** rather than the file for notebooks (https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/).